### PR TITLE
Fixed: Event image upload error when title has special characters

### DIFF
--- a/components/create_event_form.tsx
+++ b/components/create_event_form.tsx
@@ -273,7 +273,7 @@ const CreateEventForm = ({
         }
       }
 
-      const fileName = `${formData.title}_${Date.now()}-${Math.random().toString(36).substring(7)}`;
+      const fileName = `${Date.now()}-${Math.random().toString(36).substring(7)}`; // Changed to use random characters instead of title
       const { data: uploadResult, error: uploadError } = await supabase.storage
         .from("event-images")
         .upload(fileName, photoFile, {


### PR DESCRIPTION
**Fixed:** On Create Event, putting special characters on Event Title, gives an error.
Solution: do not include the title in the filename before uploading the image. 